### PR TITLE
Use version ~2.14.1 of commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "buffer": "false"
   },
   "dependencies": {
-    "commander": "~2.13.1",
+    "commander": "~2.14.1",
     "exit-on-epipe": "~1.0.1"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "blanket": "~1.2.3",
     "@sheetjs/uglify-js": "~2.7.3",
     "@types/node": "^8.0.7",
-    "@types/commander": "^2.9.0",
+    "@types/commander": "^2.12.0",
     "dtslint": "^0.1.2",
     "typescript": "2.2.0"
   },


### PR DESCRIPTION
Hi there,

The version of commander specified in the last package json is invalid. I updated it to the latest version which seems to have no breaking changes although I have not run the test suite.

Cheers,
David